### PR TITLE
fix notebook rendering issues on github

### DIFF
--- a/doc/rate_equations_derivation.ipynb
+++ b/doc/rate_equations_derivation.ipynb
@@ -182,9 +182,21 @@
     "    g_2 & g_2 & g_2 & g_2 \\\\\n",
     "    g_3 & g_3 & g_3 & g_3 \\\\\n",
     "\\end{bmatrix}\n",
-    "$$\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The matrix $\\mathbf{R} \\equiv [\\mathbf{G} \\circ \\frac{1}{\\mathbf{G^T}}]^T \\circ \\mathbf{1}_{U_{4x4}}$\n",
-    "is a strictly upper triangular matrix of the ratios of degeneracies ($\\circ$ denotes element-wise multiplication):\n",
+    "is a strictly upper triangular matrix of the ratios of degeneracies ($\\circ$ denotes element-wise multiplication):"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "$$ \n",
     "\\mathbf{R} = \n",
     "\\left[\n",
@@ -216,7 +228,7 @@
     "    0  & 0               & 0               &  \\frac{g_3}{g_2} \\\\\n",
     "    0  & 0               & 0               &  0               \\\\\n",
     "\\end{bmatrix}\n",
-    "$$\n"
+    "$$"
    ]
   },
   {
@@ -240,7 +252,13 @@
     "$$\n",
     "The energy difference of a transition from level $i$ to level $j$ is $E_{ij}$. In matrix form\n",
     "the matrix $\\mathbf{\\Delta E}$ is the energy difference of all the transitions among the levels.\n",
-    "The lower triangular part $i > j$ represents the transitions from higher to lower energies.\n",
+    "The lower triangular part $i > j$ represents the transitions from higher to lower energies.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "$$ \n",
     "\\mathbf{\\Delta E} = \n",
     "\\begin{bmatrix}\n",
@@ -279,7 +297,13 @@
     "of the photon.  $B_{ul}$ can be written as a strictly lower triangular matrix $\\mathbf{B_e}$\n",
     "(similar to $\\mathbf{A}$). On the other hand, $B_{lu}$ can be expressed as a strictly upper\n",
     "triangular matrix $\\mathbf{B_a}$ with zeros on the diagonal. We define the matrix $\\mathbf{B}$\n",
-    "such that:\n",
+    "such that:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "$$ \n",
     "\\mathbf{B} \\equiv\n",
     "\\begin{bmatrix}\n",
@@ -297,8 +321,20 @@
     "    B_{30} & B_{31}                & B_{32}                &  0 \\\\\n",
     "\\end{bmatrix}\n",
     "= \\mathbf{B_e} + \\mathbf{B_a}\n",
-    "$$\n",
-    "where $\\mathbf{B_e}$ is related to $\\mathbf{A}$ through:\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "where $\\mathbf{B_e}$ is related to $\\mathbf{A}$ through:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "$$\n",
     "\\mathbf{B_e} = \n",
     "\\begin{bmatrix}\n",
@@ -307,8 +343,20 @@
     "    B_{e_{20}} & B_{e_{21}}  & 0          &  0 \\\\\n",
     "    B_{e_{30}} & B_{e_{31}}  & B_{e_{32}} &  0 \\\\\n",
     "\\end{bmatrix} = \\frac{c^3}{8 \\pi h} \\frac{1}{\\mathbf{\\nu}^3} \\circ \\mathbf{A}\n",
-    "$$\n",
-    "and $\\mathbf{B_a}$ is related to $\\mathbf{B_e}$ through:\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and $\\mathbf{B_a}$ is related to $\\mathbf{B_e}$ through:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "$$\n",
     "\\mathbf{B_a} =\n",
     "\\begin{bmatrix}\n",
@@ -371,6 +419,8 @@
     "$$ \n",
     "\\mathbf{K} = \\mathbf{K_{\\rm dex}} + \\mathbf{K_{\\rm ex}}\n",
     "$$\n",
+    "\n",
+    "$$\n",
     "\\begin{equation}\n",
     "\\begin{split}\n",
     "  &\n",
@@ -416,6 +466,7 @@
     "\\end{bmatrix}\n",
     "\\end{split}\n",
     "\\end{equation}\n",
+    "$$\n",
     "The relationship between $\\mathbf{K_{\\rm ex}}$ and $\\mathbf{K_{\\rm dex}}$ can be\n",
     "written in matrix form as:\n",
     "$$ \n",
@@ -468,10 +519,20 @@
     "                                           % cell 3,3\n",
     "   \\end{array}\n",
     "\\right]\n",
-    "$$ \n",
-    "\n",
-    "\n",
-    "The diagonal terms of $\\mathbf{M}$ are defined as:\n",
+    "$$ "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The diagonal terms of $\\mathbf{M}$ are defined as:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "$$\n",
     "\\mathbf{D}\n",
     "=\n",
@@ -498,13 +559,24 @@
     "       &   &   &-(K_{30} + K_{31} + K_{32}) n_c\n",
     "   \\end{array}\n",
     "\\right]\n",
-    "$$\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "and $\\mathbf{O}$ is the matrix holding the offdiagonal terms:\n",
     "\n",
     "$$\n",
     "\\mathbf{O} = \\left( \\mathbf{A + B J_\\nu + K}n_c \\right)^T\\\\\n",
-    "$$\n",
-    "\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "$$\n",
     "\\mathbf{O} = \n",
     "\\left[\n",
@@ -668,9 +740,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/styles/notebook.css
+++ b/styles/notebook.css
@@ -1,0 +1,147 @@
+<link href='http://fonts.googleapis.com/css?family=Fenix' rel='stylesheet' type='text/css'>
+<link href='http://fonts.googleapis.com/css?family=Alegreya+Sans:100,300,400,500,700,800,900,100italic,300italic,400italic,500italic,700italic,800italic,900italic' rel='stylesheet' type='text/css'>
+<link href='http://fonts.googleapis.com/css?family=Source+Code+Pro:300,400' rel='stylesheet' type='text/css'>
+<style>
+
+/*
+Adapted from Lorena Barba style file
+https://github.com/barbagroup/AeroPython/blob/master/styles/custom.css
+*/
+
+@font-face {
+    font-family: "Computer Modern";
+    src: url('http://mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmunss.otf');
+}
+
+
+#notebook_panel { /* main background */
+    background: rgb(245,245,245);
+}
+
+div.cell { /* set cell width */
+    width: 875px;
+}
+
+div #notebook { /* centre the content */
+    background: #fff; /* white background for content */
+    width: 1000px;
+    margin: auto;
+    padding-left: 0em;
+}
+
+#notebook li { /* More space between bullet points */
+margin-top:0.8em;
+}
+
+/* draw border around running cells */
+div.cell.border-box-sizing.code_cell.running {
+    border: 1px solid #111;
+}
+
+/* Put a solid color box around each cell and its output, visually linking them*/
+div.cell.code_cell {
+    background-color: rgb(256,256,256);
+    border-radius: 0px;
+    padding: 0.5em;
+    margin-left:1em;
+    margin-top: 1em;
+}
+
+div.text_cell_render{
+    font-family: 'Alegreya Sans' sans-serif;
+    line-height: 140%;
+    font-size: 125%;
+    font-weight: 400;
+    width:750px;
+    margin-left:auto;
+    margin-right:auto;
+}
+
+/* Formatting for header cells */
+.text_cell_render h1 {
+    font-family: 'Alegreya Sans', sans-serif;
+    font-style:regular;
+    font-weight: 200;
+    font-size: 50pt;
+    line-height: 100%;
+    color:#CD2305;
+    margin-bottom: 0.5em;
+    margin-top: 0.5em;
+    display: block;
+}
+.text_cell_render h2 {
+    font-family: 'Fenix', serif;
+    font-size: 22pt;
+    line-height: 100%;
+    margin-bottom: 0.1em;
+    margin-top: 0.3em;
+    display: block;
+}
+
+.text_cell_render h3 {
+    font-family: 'Fenix', serif;
+    margin-top:12px;
+    font-size: 16pt;
+    margin-bottom: 3px;
+    font-style: regular;
+}
+
+.text_cell_render h4 {    /*Use this for captions*/
+    font-family: 'Fenix', serif;
+    font-size: 2pt;
+    text-align: center;
+    margin-top: 0em;
+    margin-bottom: 2em;
+    font-style: regular;
+}
+
+.text_cell_render h5 {  /*Use this for small titles*/
+    font-family: 'Alegreya Sans', sans-serif;
+    font-weight: 300;
+    font-size: 16pt;
+    color: #CD2305;
+    font-style: italic;
+    margin-bottom: .5em;
+    margin-top: 0.5em;
+    display: block;
+}
+
+.text_cell_render h6 { /*use this for copyright note*/
+    font-family: 'Source Code Pro', sans-serif;
+    font-weight: 300;
+    font-size: 9pt;
+    line-height: 100%;
+    color: grey;
+    margin-bottom: 1px;
+    margin-top: 1px;
+}
+
+    .CodeMirror{
+            font-family: "Source Code Pro";
+            font-size: 90%;
+    }
+/*    .prompt{
+        display: None;
+    }*/
+
+
+    .warning{
+        color: rgb( 240, 20, 20 )
+        }
+</style>
+<script>
+    MathJax.Hub.Config({
+                        TeX: {
+                           extensions: ["AMSmath.js"],
+                           equationNumbers: { autoNumber: "AMS", useLabelIds: true}
+                           },
+                tex2jax: {
+                    inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+                    displayMath: [ ['$$','$$'], ["\\[","\\]"] ]
+                },
+                displayAlign: 'center', // Change this to 'center' to center equations.
+                "HTML-CSS": {
+                    styles: {'.MathJax_Display': {"margin": 4}}
+                }
+        });
+</script>


### PR DESCRIPTION
Split markdown cells with too much text into smaller cells. Github was having problems rendering
these large cells and was displaying tex as plain text